### PR TITLE
removed unnecessary "code here" line

### DIFF
--- a/context.js
+++ b/context.js
@@ -75,8 +75,6 @@ function whatIsThis() {
   return this
 }
 
-//Code Here
-
 // uncomment the line below and tell us what the context of "this" is for whatIsThis()
 //let context1 = ???
 


### PR DESCRIPTION
The instructions do not require students to write code on this line, so it is unnecessary and makes the exercise unclear.